### PR TITLE
Translate de primer 'Functions II'

### DIFF
--- a/primer/primer.de.robomarkup
+++ b/primer/primer.de.robomarkup
@@ -255,7 +255,7 @@ while left_count < 3
 
 
 #!unlock type{primer} id{fun-2}
-# Functions II
+# Funktionen II
 
 Funktionen können auch Zahlen entgegennehmen oder zurückgeben.
 


### PR DESCRIPTION
I just noticed this heading looks like it was left untranslated. @bert2 can you confirm this change is correct?

And of course I noticed it just after pushing 1.10. But it's not a huge issue I think.