### PR TITLE
Translate German functions docs

### DIFF
--- a/company/company.de.robomarkup
+++ b/company/company.de.robomarkup
@@ -27,9 +27,9 @@ Bestätigt
 #!company id{c-arrive}
 # Re: Iceni Bergungsankunftsbericht
 
-Du hast also einen Roboter gefunden? Sieht süß aus, wenn auch etwas primitiv. Aber wenn das die beste Bergung ist, die Sie finden können ... Nun, sagen wir einfach, sie deckt nicht einmal die Kosten der billig Nährstoffsuppenrationen, die Sie zweifellos genießen, während Sie dies lesen.
+Du hast also einen Roboter gefunden? Sieht süß aus, wenn auch etwas primitiv. Aber wenn das die beste Bergung ist, die Sie finden können... Nun, sagen wir einfach, sie deckt nicht einmal die Kosten der billig Nährstoffsuppenrationen, die Sie zweifellos genießen, während Sie dies lesen.
 
-Habe die von Ihnen gesendeten Scans überprüft und ich muss sagen, dass ich ein wenig verärgert bin. Wenn ich gewollt hätte, dass Sie verrostetes Metall und nutzlosen Abfall findest, hätten Sie einfach auf der Erde bleiben können. Iceni war ein hochmodernes Schiff. Wo sind alle Schiffskomponenten, Verkleidungen und Computer? Wo sind die Kolonisten ???
+Habe die von Ihnen gesendeten Scans überprüft und ich muss sagen, dass ich ein wenig verärgert bin. Wenn ich gewollt hätte, dass Sie verrostetes Metall und nutzlosen Abfall finden, hätten Sie einfach auf der Erde bleiben können. Iceni war ein hochmodernes Schiff. Wo sind all die Schiffskomponenten, Verkleidungen und Computer? Wo sind die Kolonisten???
 
 Das Wetter an der Oberfläche muss viel härter sein als erwartet, um es so auseinander zu reißen. Kein Wunder, dass Sie keine Überlebenden auffinden. Daher stimme ich Ihrer Idee zu, diesen Roboter, den Sie an Ihrer Stelle gefunden haben, zu verwenden. Vorsicht ist besser als Nachsicht, da ich in diesem Quartal KEINEN von euch mehr verlieren kann.
 
@@ -42,9 +42,9 @@ Judith
 #!company id{c-underground}
 # Re: Iceni Bergungsbericht # 6
 
-Endlich eine gute Nachricht! So wie es aussieht, handelt es sich. bei den Ergebnissen ihres Scans, um einen unterirdischen Eingang. Sie gingen unter die Erde! Ich glaube nicht, dass ich jemals zuvor von sowas gehört habe.
+Endlich eine gute Nachricht! So wie es aussieht, handelt es sich bei den Ergebnissen ihres Scans, um einen unterirdischen Eingang. Sie gingen unter die Erde! Ich glaube nicht, dass ich jemals zuvor von sowas gehört habe.
 
-Das bedeutet, dass die Kolonisten NICHT alle erfroren sind / von diesen eisigen Winden in den Himmel getragen werden. Seltene Metalle, Transmitter ... sogar die Leute selbst könnten noch da unten sein.
+Das bedeutet, dass die Kolonisten NICHT alle erfroren sind bzw. von diesen eisigen Winden in den Himmel getragen wurden. Seltene Metalle, Transmitter ... sogar die Leute selbst könnten noch da unten sein.
 
 Ich kann es kaum erwarten, es Nigel zu sagen. Ooh ... vielleicht ist es eine Iris-Sache. Oder sogar eine Martin-Sache! Sie finden etwas Gewinn bringendes und ich könnte vor Ende des Geschäftsjahres auf Titan mit Big M zu Mittag essen. Los Team!
 

--- a/function/fun.de.robomarkup
+++ b/function/fun.de.robomarkup
@@ -1,185 +1,185 @@
 // Pseudo markup format see ./README.md
 
 #!unlock type{short} id{s-left}
-`robo_left() ` stays on the same tile, moves left
+`robo_left() ` bleib auf Kachel, drehe nach links
 
 
 #!unlock type{short} id{s-forward}
-`robo_forward() ` moves forward (also veers right because triangles)
+`robo_forward() ` vorwärts bewegen (dreht auch nach rechts wegen Dreiecken)
 
 
 #!unlock type{short} id{s-scan}
-`robo_scan() ` scan the tile in front returns `-999`: unknown, `-1`: absent, `1`: normal, `2`: exit
+`robo_scan() ` prüfe Kachel voraus, ergibt `-999`: unbekannt, `-1`: abwesend, `1`: normal, `2`: Ausgang
 
 
 #!unlock type{short} id{s-scan-u1}
-`robo_scan() ` scan the tile in front returns `-999`: unknown, `-1`: absent, `1`: normal, `2`: exit, `10`: power switch
+`robo_scan() ` prüfe Kachel voraus, ergibt `-999`: unbekannt, `-1`: abwesend, `1`: normal, `2`: Ausgang, `10`: Netzschalter
 
 
 #!unlock type{short} id{s-scan-u2}
-`robo_scan() ` scan the tile in front returns `-999`: unknown, `-1`: absent, `1`: normal, `2`: exit, `10`: power switch, `11`: location data store
+`robo_scan() ` prüfe Kachel voraus, ergibt `-999`: unbekannt, `-1`: abwesend, `1`: normal, `2`: Ausgang, `10`: Netzschalter, `11`: Standort-Speicher
 
 
 #!unlock type{short} id{s-scan-u3}
-`robo_scan() ` scan the tile in front returns `-999`: unknown, `-1`: absent, `1`: normal, `2`: exit, `10`: power switch, `11`: location data store, `12`: direction data store
+`robo_scan() ` prüfe Kachel voraus, ergibt `-999`: unbekannt, `-1`: abwesend, `1`: normal, `2`: Ausgang, `10`: Netzschalter, `11`: Standort-Speicher, `12`: Richtungs-Speicher
 
 
 #!unlock type{short} id{s-scan-u4}
-`robo_scan() ` scan the tile in front returns `-999`: unknown, `-1`: absent, `1`: normal, `2`: exit, `3`: launcher, `10`: power switch, `11`: location data store, `12`: direction data store
+`robo_scan() ` prüfe Kachel voraus, ergibt `-999`: unbekannt, `-1`: abwesend, `1`: normal, `2`: Ausgang, `3`: Wurframpe, `10`: Netzschalter, `11`: Standort-Speicher, `12`: Richtungs-Speicher
 
 
 #!unlock type{short} id{s-use}
-`robo_use() ` use current tile, returns: power switch `1`: on, `0`: off
+`robo_use() ` benutze aktuelle Kachel, ergibt: Netzschalter `1`: an, `0`: aus
 
 
 #!unlock type{short} id{s-use-u2}
-`robo_use() ` use current tile, returns: power switch `1`: on, `0`: off, location data store: safe location id
+`robo_use() ` benutze aktuelle Kachel, ergibt: Netzschalter `1`: an, `0`: aus, Standort-Speicher: sichere Standort ID
 
 
 #!unlock type{short} id{s-use-u3}
-`robo_use() ` use current tile, returns: power switch `1`: on, `0`: off, location data store: safe location id, directions `1`: up, `2`: right
+`robo_use() ` benutze aktuelle Kachel, ergibt: Netzschalter `1`: an, `0`: aus, Standort-Speicher: sichere Standort ID, Richtungs-Speicher `1`: oben, `2`: rechts
 
 
 #!unlock type{short} id{s-use-u4}
-`robo_use() ` use current tile, returns: power switch `1`: on, `0`: off, location data store: safe location id, directions `1`: up, `2`: right, `3`: down, `4`: left
+`robo_use() ` benutze aktuelle Kachel, ergibt: Netzschalter `1`: an, `0`: aus, Standort-Speicher: sichere Standort-ID, Richtungs-Speicher `1`: oben, `2`: rechts, `3`: unten, `4`: links
 
 
 #!unlock type{short} id{s-detect-adjacent}
-`robo_detect_adjacent() ` returns the number of non-absent adjacent tiles, unaffected by unknowns
+`robo_detect_adjacent() ` gibt die Anzahl nicht abwesender Nachbar-Kacheln zurück, unbeinträchtigt durch unbekannte
 
 
 #!unlock type{short} id{s-location}
-`robo_location() ` returns current location id
+`robo_location() ` gibt die Standort-ID der aktuellen Kachel zurück
 
 
 #!unlock type{short} id{s-forward-location}
-`robo_forward_location() ` returns location id of tile in front
+`robo_forward_location() ` gibt die Standort-ID der Kachel voraus zurück
 
 
 #!unlock type{short} id{s-detect-3}
-`robo_detect_3() ` returns the number of non-absent forward 3 tiles (rightward), unaffected by unknowns
+`robo_detect_3() ` gibt die Anzahl der 3 Kacheln voraus (rechtsliegend) zurück, die nicht abwesend sind, unbeinträchtigt durch unbekannte
 
 
 #!unlock type{short} id{s-detect-3l}
-`robo_detect_3l() ` returns the number of non-absent forward 3 tiles (leftward), unaffected by unknowns
+`robo_detect_3l() ` gibt die Anzahl der 3 Kacheln voraus (linksliegend) zurück, die nicht abwesend sind, unbeinträchtigt durch unbekannte
 
 
 #!unlock type{short} id{s-probo-left}
-`probo_left() ` stays on the same tile, turns left
+`probo_left() ` bleib auf Kachel, drehe nach links
 
 
 #!unlock type{short} id{s-probo-forward}
-`probo_forward() ` moves forward (also turns somewhat right)
+`probo_forward() ` vorwärts bewegen (dreht auch etwas nach rechts)
 
 
 #!unlock type{short} id{s-probo-scan}
-`probo_scan() ` scan the tile in front returns `-999`: unknown, `-1`: absent, `1`: normal, `2`: exit, `3`: launcher, `10`: power switch, `11`: location data store, `12`: direction data store
+`probo_scan() ` prüfe aktuelle Kachel, ergibt `-999`: unbekannt, `-1`: abwesend, `1`: normal, `2`: Ausgang, `3`: Wurframpe, `10`: Netzschalter, `11`: Standort-Speicher, `12`: Richtungs-Speicher
 
 
 #!unlock type{short} id{s-probo-location}
-`probo_location() ` returns current location
+`probo_location() ` gib aktuellen Standort zurück
 
 
 #!unlock type{short} id{s-probo-use}
-`probo_use() ` use current tile, returns: power switch `1`: on, `0`: off, location data store: safe location id, directions `1`: up, `2`: right, `3`: down, `4`: left
+`probo_use() ` benutze aktuelle Kachel, ergibt: Netzschalter `1`: an, `0`: aus, Standort-Speicher: sichere Standort-ID, Richtungs-Speicher `1`: oben, `2`: rechts, `3`: unten, `4`: links
 
 
 #!unlock type{short} id{s-transmit}
-`transmit(subject,data) ` transmits data on a subject
+`transmit(subject,data) ` sende Daten zu einem Betreff
 
 
 #!unlock type{short} id{s-receive}
-`receive(subject) ` consumes & returns oldest subject data value or `-20000` if none exists
+`receive(subject) ` konsumiere & gib ältesten Datenwert zum Betreff zurück (oder `-20000`, wenn keine Werte existieren)
 
 
 #!unlock type{functions} id{left-forward}
-`robo_left()` Each call instructs the robot to move to the next side of the current tile, counter-clockwise. Runtime $tu{robo_left()} Mimas-seconds (ms).
+`robo_left()` Jeder Aufruf instruiert den Roboter sich gegen den Uhrzeigersinn zur nächsten Seite der aktuellen Kacheln zu bewegen. Laufzeit $tu{robo_left()} Mimas-Sekunden (ms).
 $render{robo_left}
-`robo_forward()` Instructs the robot to move forward onto a tile it's currently facing. The robot will favour veering to the right hand side when doing this. Runtime $tu{robo_forward()} ms.
+`robo_forward()` Befiehlt dem Roboter sich vorwärts auf die Kachel zu bewegen, der er gegenübersteht. Der Roboter wird dabei bevorzugt nach rechts steuern. Laufzeit $tu{robo_forward()} ms.
 $render{robo_forward}
 
 
 #!unlock type{function} id{scan}
-`robo_scan()` Scans the tile in front, returns a value indicating the tile properties. `1` means a normal tile, `2` an exit, `-1` means no tile at all, `-999` means unknown.  Runtime $tu{robo_scan()} ms.
+`robo_scan()` Überprüft die Kachel voraus und gibt den Kachel-Typ als Zahl zurück. `1` ist eine normale Kachel, `2` ein Ausgang, `-1` bedeutet keine Kachel, `-999` bedeutet unbekannt. Laufzeit $tu{robo_scan()} ms.
 
 $render{robo_scan}
 
 
 #!unlock type{function-update} id{scan-u1}
-`robo_scan()` Scans the tile in front, returns a value indicating the tile properties. `1` means a normal tile, `2`: exit, `-1`: no tile at all, `-999`: unknown, `10`: power switch. Runtime $tu{robo_scan()} ms.
+`robo_scan()` Überprüft die Kachel voraus und gibt den Kachel-Typ als Zahl zurück. `1` ist eine normale Kachel, `2`: Ausgang, `-1`: keine Kachel, `-999`: unbekannt, `10`: Netzschalter. Laufzeit $tu{robo_scan()} ms.
 
 $render{robo_scan}
 
 
 #!unlock type{function-update} id{scan-u2}
-`robo_scan()` Scans the tile in front, returns a value indicating the tile properties. `1` means a normal tile, `2`: exit, `-1`: no tile at all, `-999`: unknown, `10`: power switch, `11`: location data store. Runtime $tu{robo_scan()} ms.
+`robo_scan()` Überprüft die Kachel voraus und gibt den Kachel-Typ als Zahl zurück. `1` ist eine normale Kachel, `2`: Ausgang, `-1`: keine Kachel, `-999`: unbekannt, `10`: Netzschalter, `11`: Standort-Speicher. Laufzeit $tu{robo_scan()} ms.
 
 $render{robo_scan}
 
 
 #!unlock type{function-update} id{scan-u3}
-`robo_scan()` Scans the tile in front, returns a value indicating the tile properties. `1` means a normal tile, `2`: exit, `-1`: no tile at all, `-999`: unknown, `10`: power switch, `11`: location data store, `12`: direction data store. Runtime $tu{robo_scan()} ms.
+`robo_scan()` Überprüft die Kachel voraus und gibt den Kachel-Typ als Zahl zurück. `1` ist eine normale Kachel, `2`: Ausgang, `-1`: keine Kachel, `-999`: unbekannt, `10`: Netzschalter, `11`: Standort-Speicher, `12`: Richtungs-Speicher. Laufzeit $tu{robo_scan()} ms.
 
 $render{robo_scan}
 
 
 #!unlock type{function-update} id{scan-u4}
-`robo_scan()` Scans the tile in front, returns a value indicating the tile properties. `1` means a normal tile, `2`: exit, `-1`: no tile at all, `-999`: unknown, `3`: launcher tile, `10`: power switch, `11`: location data store, `12`: direction data store. Runtime $tu{robo_scan()} ms.
+`robo_scan()` Überprüft die Kachel voraus und gibt den Kachel-Typ als Zahl zurück. `1` ist eine normale Kachel, `2`: Ausgang, `-1`: keine Kachel, `-999`: unbekannt, `3`: Wurframpe, `10`: Netzschalter, `11`: Standort-Speicher, `12`: Richtungs-Speicher. Laufzeit $tu{robo_scan()} ms.
 
 $render{robo_scan}
 
 
 #!unlock type{function} id{use}
-`robo_use()` Operates on the current tile returning tile specific data, or `0` otherwise. Runtime $tu{robo_use()} ms
+`robo_use()` Bedient die aktuelle Kachel und gibt Kachel-spezifische Daten oder `0` zurück. Laufzeit $tu{robo_use()} ms
 $render{robo_use}
 
 
 #!unlock type{function-update} id{use-u1}
-`robo_use()` Operates on the current tile returning tile specific data, or `0` otherwise. Runtime $tu{robo_use()} ms
-- Power switch: Returns `1`: on, `0` off. Additional runtime +$tu{robo_use_power} ms
+`robo_use()` Bedient die aktuelle Kachel und gibt Kachel-spezifische Daten oder `0` zurück. Laufzeit $tu{robo_use()} ms
+- Netzschalter: Ergibt `1`: an, `0` aus. Zusätliche Laufzeit +$tu{robo_use_power} ms
 $render{robo_use}
 
 
 #!unlock type{function-update} id{use-u2}
-`robo_use()` Operates on the current tile returning tile specific data, or `0` otherwise. Runtime $tu{robo_use()} ms
-- Power switch: Returns `1`: on, `0` off. Additional runtime +$tu{robo_use_power} ms
-- Location data store: Returns safe location id. Additional runtime +$tu{robo_use_location} ms
+`robo_use()` Bedient die aktuelle Kachel und gibt Kachel-spezifische Daten oder `0` zurück. Laufzeit $tu{robo_use()} ms
+- Netzschalter: Ergibt `1`: an, `0` aus. Zusätliche Laufzeit +$tu{robo_use_power} ms
+- Standort-Speicher: Gibt sichere Standort-ID zurück. Zusätliche Laufzeit +$tu{robo_use_location} ms
 $render{robo_use-2}
 
 
 #!unlock type{function-update} id{use-u3}
-`robo_use()` Operates on the current tile returning tile specific data, or `0` otherwise. Runtime $tu{robo_use()} ms
-- Power switch: Returns `1`: on, `0` off. Additional runtime +$tu{robo_use_power} ms
-- Location data store: Returns safe location id. Additional runtime +$tu{robo_use_location} ms
-- Direction data store: Returns `1`: up, `2`: right. Additional runtime +$tu{robo_use_direction} ms
+`robo_use()` Bedient die aktuelle Kachel und gibt Kachel-spezifische Daten oder `0` zurück. Laufzeit $tu{robo_use()} ms
+- Netzschalter: Ergibt `1`: an, `0` aus. Zusätliche Laufzeit +$tu{robo_use_power} ms
+- Standort-Speicher: Gibt sichere Standort-ID zurück. Zusätliche Laufzeit +$tu{robo_use_location} ms
+- Richtungs-Speicher: Ergibt `1`: oben, `2`: rechts. Zusätliche Laufzeit +$tu{robo_use_direction} ms
 $render{robo_use-3}
 
 
 #!unlock type{function-update} id{use-u4}
-`robo_use()` Operates on the current tile returning tile specific data, or `0` otherwise. Runtime $tu{robo_use()} ms
-- Power switch: Returns `1`: on, `0` off. Additional runtime +$tu{robo_use_power} ms
-- Location data store: Returns safe location id. Additional runtime +$tu{robo_use_location} ms
-- Direction data store: Returns `1`: up, `2`: right, `3`: down, `4`: left. Additional runtime +$tu{robo_use_direction} ms
+`robo_use()` Bedient die aktuelle Kachel und gibt Kachel-spezifische Daten oder `0` zurück. Laufzeit $tu{robo_use()} ms
+- Netzschalter: Ergibt `1`: an, `0` aus. Zusätliche Laufzeit +$tu{robo_use_power} ms
+- Standort-Speicher: Gibt sichere Standort-ID zurück. Zusätliche Laufzeit +$tu{robo_use_location} ms
+- Richtungs-Speicher: Ergibt `1`: oben, `2`: rechts, `3`: unten, `4`: links. Zusätliche Laufzeit +$tu{robo_use_direction} ms
 $render{robo_use-3}
 
 
 #!unlock type{function} id{forward-location}
-`robo_forward_location()` Returns the id of the tile the robot is facing. Runtime $tu{robo_forward_location()} ms.
+`robo_forward_location()` Gibt die ID der Kachel zurück, die dem Roboter gegenüber liegt. Laufzeit $tu{robo_forward_location()} ms.
 
 $render{robo_forward_location}
 ```no_run
 var location = robo_forward_location()  # 8823
 ```
-Each tile in a level has a distinct id number (positive & non-zero).
+Jede Kachel in einem Level hat eine eindeutige ID-Nummer (größer `0`).
 
 
 #!unlock type{function} id{location}
-`robo_location()` Returns the id of the current tile the robot is standing on. Runtime $tu{robo_location()} ms.
+`robo_location()` Gibt die ID der Kachel, auf der der Roboter steht, zurück. Laufzeit $tu{robo_location()} ms.
 $render{robo_location}
 
 
 #!unlock type{function} id{detect-adjacent}
-`robo_detect_adjacent()` Returns the total number of tiles adjacent to the current position. `0`, `1`, `2` or `3`. This works correctly even if some of the tiles are unknown to a `robo_scan()` call.  Runtime $tu{robo_detect_adjacent()} ms.
+`robo_detect_adjacent()` Gibt die Anzahl aller Nachbar-Kacheln der aktuellen Position zurück. `0`, `1`, `2` oder `3`. Dies funktioniert auch dann korrekt, wenn manche der Kacheln laut `robo_scan()` unbekannt sind. Laufzeit $tu{robo_detect_adjacent()} ms.
 $render{robo_detect_adjacent}
 ```no_run
 var its_safe = robo_detect_adjacent() is 3
@@ -187,44 +187,44 @@ var its_safe = robo_detect_adjacent() is 3
 
 
 #!unlock type{function} id{detect-3}
-`robo_detect_3()` Returns the total number of tiles in a straight right-veering line. This works correctly even if some of the tiles are unknown to a `robo_scan()` call. Runtime $tu{robo_detect_3()} ms.
+`robo_detect_3()` Gibt die Anzahl aller Kacheln in einer geraden, rechtsdrehenden Linie zurück. Dies funktioniert auch dann korrekt, wenn manche der Kacheln laut `robo_scan()` unbekannt sind. Laufzeit $tu{robo_detect_3()} ms.
 
 $render{robo_detect_3}
 
 
 #!unlock type{function} id{detect-3l}
-`robo_detect_3l()` Returns the total number of tiles in a straight left-veering line. Similar to `robo_detect_3()`. Runtime $tu{robo_detect_3l()} ms.
+`robo_detect_3l()` Gibt die Anzahl aller Kacheln in einer geraden, linksdrehenden Linie zurück. Ähnlich zu `robo_detect_3()`. Laufzeit $tu{robo_detect_3l()} ms.
 
 $render{robo_detect_3l}
 
 
 #!unlock type{functions} id{probo}
-`probo_left()` Rotate left to face the next side of the current tile, counter-clockwise. Runtime $tu{probo_left()} ms.
+`probo_left()` Drehung nach links zur nächsten Seite der aktuellen Kachel. Laufzeit $tu{probo_left()} ms.
 
-`probo_forward()` Move the probe forward onto the tile space it's currently facing. New probe orientation veers rightwards. Runtime $tu{probo_forward()} ms.
+`probo_forward()` Bewege die Sonde vorwärts auf die Kachel-Fläche, die ihr gegenüber liegt. Neue Ausrichtung der Sonde dreht nach rechts ab. Laufzeit $tu{probo_forward()} ms.
 
-`probo_location()` Returns the id of the current tile. Runtime $tu{probo_location()} ms.
+`probo_location()` Gibt die ID der aktuellen Kachel zurück. Laufzeit $tu{probo_location()} ms.
 
-`probo_scan()` Scans the current tile, returns a value indicating the tile properties. `1` means a normal tile, `2`: exit, `-1`: no tile at all, `-999`: unknown, `3`: launcher tile, `10`: power switch, `11`: location data store, `12`: direction data store. Runtime $tu{probo_scan()} ms.
+`probo_scan()` Prüft die aktuelle Kachel und gibt den Kachel-Typ als Zahl zurück. `1` ist eine normale Kachel, `2`: Ausgang, `-1`: keine Kachel, `-999`: unbekannt, `3`: Wurframpe, `10`: Netzschalter, `11`: Standort-Speicher, `12`: Richtungs-Speicher. Laufzeit $tu{probo_scan()} ms.
 
 $render{probo_scan}
 
 
 #!unlock type{function-update} id{probo-scan-u1}
-`probo_scan()` Scans the current tile, returns a value indicating the tile properties. `1` means a normal tile, `2`: exit, `-1`: no tile at all, `-999`: unknown, `3`: north launcher, `4`: south-east launcher, `5`: south-west launcher, `10`: power switch, `11`: location data store, `12`: direction data store. Runtime $tu{probo_scan()} ms.
+`probo_scan()` Prüft die aktuelle Kachel und gibt den Kachel-Typ als Zahl zurück. `1` ist eine normale Kachel, `2`: Ausgang, `-1`: keine Kachel, `-999`: unbekannt, `3`: Nord-Wurframpe, `4`: Südost-Wurframpe, `5`: Südwest-Wurframpe, `10`: Netzschalter, `11`: Standort-Speicher, `12`: Richtungs-Speicher. Laufzeit $tu{probo_scan()} ms.
 
 $render{probo_scan-2}
 
 
 #!unlock type{functions} id{transmit}
-`transmit(subject,data)` Transmit a single `data` value associated with a `subject` value. Such transmissions may be received by other robots. Runtime $tu{transmit(vv)} ms.
+`transmit(subject,data)` Versendet einen einzelnen Datenwert `data` zusammen mit dem Betreff-Wert `subject`. Derartige Übertragungen können von anderen Robotern empfangen werden. Laufzeit $tu{transmit(vv)} ms.
 
-`receive(subject)` Receive a single data value transmitted by another robot with matching `subject` value. Data transmissions are received in order. If there is no subject transmission to receive returns `-20000`. Runtime $tu{receive(v)} ms.
+`receive(subject)` Empfängt einen einzelnen Datenwert, der von einem anderen Roboter mit dem passendem Betreff-Wert versendet wurde. Datenübertragungen werden geordnet empfangen. Gibt `-20000` zurück, wenn keine Übertragung zum Betreff empfangen werden kann. Laufzeit $tu{receive(v)} ms.
 
 
 #!unlock type{function} id{probo-use}
-`probo_use()` Operates on the current tile returning tile specific data, or `0` otherwise. Runtime $tu{probo_use()} ms
-- Power switch: Returns `1`: on, `0` off. Additional runtime +$tu{robo_use_power} ms
-- Location data store: Returns safe location id. Additional runtime +$tu{robo_use_location} ms
-- Direction data store: Returns `1`: up, `2`: right, `3`: down, `4`: left. Additional runtime +$tu{robo_use_direction} ms
+`probo_use()` Bedient die aktuelle Kachel und gibt Kachel-spezifische Daten oder `0` zurück. Laufzeit $tu{probo_use()} ms
+- Netzschalter: Ergibt `1`: an, `0` aus. Zusätliche Laufzeit +$tu{robo_use_power} ms
+- Standort-Speicher: Gibt sichere Standort-ID zurück. Zusätliche Laufzeit +$tu{robo_use_location} ms
+- Richtungs-Speicher: Ergibt `1`: oben, `2`: rechts. Zusätliche Laufzeit +$tu{robo_use_direction} ms
 $render{probo_use}

--- a/function/fun.en.robomarkup
+++ b/function/fun.en.robomarkup
@@ -73,7 +73,7 @@
 
 
 #!unlock type{short} id{s-probo-scan}
-`probo_scan() ` scan the tile in front returns `-999`: unknown, `-1`: absent, `1`: normal, `2`: exit, `3`: launcher, `10`: power switch, `11`: location data store, `12`: direction data store
+`probo_scan() ` scan current tile, returns `-999`: unknown, `-1`: absent, `1`: normal, `2`: exit, `3`: launcher, `10`: power switch, `11`: location data store, `12`: direction data store
 
 
 #!unlock type{short} id{s-probo-location}
@@ -179,7 +179,7 @@ $render{robo_location}
 
 
 #!unlock type{function} id{detect-adjacent}
-`robo_detect_adjacent()` Returns the total number of tiles adjacent to the current position. `0`, `1`, `2` or `3`. This works correctly even if some of the tiles are unknown to a `robo_scan()` call.  Runtime $tu{robo_detect_adjacent()} ms.
+`robo_detect_adjacent()` Returns the total number of tiles adjacent to the current position. `0`, `1`, `2` or `3`. This works correctly even if some of the tiles are unknown to a `robo_scan()` call. Runtime $tu{robo_detect_adjacent()} ms.
 $render{robo_detect_adjacent}
 ```no_run
 var its_safe = robo_detect_adjacent() is 3


### PR DESCRIPTION
This resolves #69.

Note, that there was an error in the original short documentation for `probo_scan()` that this PR fixes as well.

This also fixes a few grammar mistakes in the German company messages.

@Squirkyy, I added you as a collaborator again. I'd appreciate another check by you 🙏 

